### PR TITLE
travis: specify trusty as the dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Travis changed their default distro to be xenial which doesn't seem to have oraclejdk8 available to it.

Their guidance was to manually specify trusty to work around the issue: https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/9