### PR TITLE
build: upgrade to java 11 and groovy 3

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,27 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B install --file pom.xml
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-dist: trusty
-language: java
-jdk:
-  - oraclejdk8
-install: mvn install -DskipTests=true -B -V
-notifications:
-  slack:
-    secure: ZhUG6+zzZeRoL4yoTbYArIvQ7VKFel3u8S7rf3oFVzvf7UkaZKH5wS/D0gcIm14XstmLB+xUyLZ7MfScF5TUZqGpQ/Bgsft5wx4rDZlWSJshPWP5i4i4VHpP/qz3D5Lf8tBpcEbxf8fTH69VRz9KqsQ7Qt4zNTAeOxotYZnj8J4=

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.vmware.vcloud</groupId>
     <artifactId>upgrade-framework-parent</artifactId>
-    <version>1.0.1</version>
+    <version>2.0.0</version>
 
     <name>upgrade-framework-parent - Upgrade Framework</name>
     <url>https://github.com/vmware/upgrade-framework/</url>
@@ -30,9 +30,9 @@
         <commons.lang3.version>3.4</commons.lang3.version>
         <commons.math.version>1.2</commons.math.version>
         <easymock.version>3.1</easymock.version>
-        <groovy.eclipse.batch.version>2.4.3-01</groovy.eclipse.batch.version>
-        <groovy.eclipse.compiler.version>2.9.2-01</groovy.eclipse.compiler.version>
-        <groovy.version>2.4.8</groovy.version>
+        <groovy.eclipse.batch.version>3.0.5-01</groovy.eclipse.batch.version>
+        <groovy.eclipse.compiler.version>3.6.0-03</groovy.eclipse.compiler.version>
+        <groovy.version>3.0.7</groovy.version>
         <jackson.version>2.9.10</jackson.version>
         <jackson.databind.version>2.9.10.1</jackson.databind.version>
         <log4j.version>1.2.17</log4j.version>
@@ -70,6 +70,7 @@
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
                 <version>${groovy.version}</version>
+                <type>pom</type>
             </dependency>
 
             <dependency>
@@ -170,7 +171,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.3.0</version>
                 </plugin>
 
                 <!-- This pulls in the MANIFEST.MF file that is maintained by the developers.
@@ -178,6 +179,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.3.2</version>
                     <configuration>
                         <archive>
                             <manifestFile>${project.basedir}/META-INF/MANIFEST.MF</manifestFile>
@@ -199,7 +201,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.3.7</version>
+                    <version>4.0.0</version>
                     <executions>
                         <execution>
                             <id>bundle-manifest</id>
@@ -226,28 +228,27 @@
         <plugins>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1.0</version>
             </plugin>
 
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <encoding>utf8</encoding>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>11</release>
                 </configuration>
             </plugin>
 
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>2.8</version>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.1</version>
+                <version>3.0.0-M5</version>
                 <configuration>
                     <groups>Unit, Minimum</groups>
                     <suiteXmlFiles>
@@ -259,7 +260,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
+                <version>3.0.1</version>
                 <configuration>
                     <show>public</show>
                 </configuration>
@@ -289,6 +290,7 @@
 
                     <plugin>
                         <artifactId>maven-source-plugin</artifactId>
+                        <version>2.2</version>
                         <executions>
                             <execution>
                                 <phase>package</phase>

--- a/upgrade-framework-core/instructions.bnd
+++ b/upgrade-framework-core/instructions.bnd
@@ -1,4 +1,4 @@
 Bundle-SymbolicName: com.vmware.upgrade
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: *
 Import-Package: *

--- a/upgrade-framework-core/pom.xml
+++ b/upgrade-framework-core/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.vmware.vcloud</groupId>
         <artifactId>upgrade-framework-parent</artifactId>
-        <version>1.0.1</version>
+        <version>2.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/upgrade-framework-distribution/pom.xml
+++ b/upgrade-framework-distribution/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.vmware.vcloud</groupId>
         <artifactId>upgrade-framework-parent</artifactId>
-        <version>1.0.1</version>
+        <version>2.0.0</version>
     </parent>
 
     <dependencies>

--- a/upgrade-framework-dsl/instructions.bnd
+++ b/upgrade-framework-dsl/instructions.bnd
@@ -1,4 +1,4 @@
 Bundle-SymbolicName: com.vmware.upgrade.dsl
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: *
 Import-Package: org.apache.commons.lang, *

--- a/upgrade-framework-dsl/pom.xml
+++ b/upgrade-framework-dsl/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.vmware.vcloud</groupId>
         <artifactId>upgrade-framework-parent</artifactId>
-        <version>1.0.1</version>
+        <version>2.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -22,6 +22,8 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
+            <version>${groovy.version}</version>
+            <type>pom</type>
         </dependency>
 
         <dependency>

--- a/upgrade-framework-dsl/src/main/java/com/vmware/upgrade/dsl/model/package-info.java
+++ b/upgrade-framework-dsl/src/main/java/com/vmware/upgrade/dsl/model/package-info.java
@@ -24,10 +24,10 @@
  * The core model objects which compose the domain specific language for defining upgrade
  * framework constructs.
  * <p>
- * A {@link com.vmware.upgrade.dsl.model.ManifestModel} consists of
- * {@link com.vmware.upgrade.dsl.model.UpgradeTaskModel}s which reference
- * {@link com.vmware.upgrade.dsl.model.UpgradeDefinitionModel}s within
- * {@link com.vmware.upgrade.dsl.model.NamespaceModel}s
+ * A com.vmware.upgrade.dsl.model.ManifestModel consists of
+ * com.vmware.upgrade.dsl.model.UpgradeTaskModels which reference
+ * com.vmware.upgrade.dsl.model.UpgradeDefinitionModels within
+ * com.vmware.upgrade.dsl.model.NamespaceModels
  * <p>
  * (Package contains Groovy classes.)
  *

--- a/upgrade-framework-dsl/src/main/java/com/vmware/upgrade/dsl/package-info.java
+++ b/upgrade-framework-dsl/src/main/java/com/vmware/upgrade/dsl/package-info.java
@@ -31,13 +31,13 @@
  * the syntax classes for constructing this model are in {@link com.vmware.upgrade.dsl.syntax}.
  * <p>
  * This package contains the objects a consumer of the language will need to directly interface
- * with. {@link com.vmware.upgrade.dsl.Loader} is the primary entry point for consuming a script.
+ * with. com.vmware.upgrade.dsl.Loader is the primary entry point for consuming a script.
  * Implementations of {@link com.vmware.upgrade.dsl.Processor} and
  * {@link com.vmware.upgrade.dsl.TaskResolver} are used to extend the language and control the
  * {@link com.vmware.upgrade.Task}s which are produced.
  * <h3>A single-file example</h3>
  * This example demonstrates defining an upgrade and sequencing it in a manifest in a single file.
- * <h4><tt>src/main/resources/upgrade/upgrade.groovy</tt></h4>
+ * <h4><code>src/main/resources/upgrade/upgrade.groovy</code></h4>
  * <pre><code>
  * foo = upgrade {
  *     name "Upgrade to do 'foo'"
@@ -74,7 +74,7 @@
  * <h3>A multi-file example</h3>
  * This example demonstrates defining an upgrade within a namespace in a file included from a
  * separate file which defines a manifest which sequences the upgrade.
- * <h4><tt>src/main/resources/upgrade/baz.groovy</tt></h4>
+ * <h4><code>src/main/resources/upgrade/baz.groovy</code></h4>
  * <pre><code>
  * bar = namespace {
  *     foo = upgrade {
@@ -84,7 +84,7 @@
  *     }
  * }
  * </code></pre>
- * <h4><tt>src/main/resources/upgrade/manifest.groovy</tt></h4>
+ * <h4><code>src/main/resources/upgrade/manifest.groovy</code></h4>
  * <pre><code>
  * import "baz.groovy"
  *
@@ -98,7 +98,7 @@
  * </code></pre>
  * <h3>A manifest file for a complex graph</h3>
  * This example demonstrates the ability defining a set of upgrades to form a non-trivial graph.
- * <h4><tt>src/main/resources/upgrade/manifest.groovy</tt></h4>
+ * <h4><code>src/main/resources/upgrade/manifest.groovy</code></h4>
  * <pre><code>
  * import "upgrades.groovy"
  *
@@ -123,7 +123,7 @@
  * <h3>An upgrade definition with complex orchestration</h3>
  * This example demonstrates the ability to define an upgrade that explicitly controls the way in
  * which a set of {@link com.vmware.upgrade.Task}s are executed.
- * <h4><tt>src/main/resources/upgrade/upgrade.groovy</tt></h4>
+ * <h4><code>src/main/resources/upgrade/upgrade.groovy</code></h4>
  * <pre><code>
  * foo = upgrade {
  *     name "Run a complex set of tasks"

--- a/upgrade-framework-dsl/src/main/java/com/vmware/upgrade/dsl/syntax/package-info.java
+++ b/upgrade-framework-dsl/src/main/java/com/vmware/upgrade/dsl/syntax/package-info.java
@@ -23,7 +23,7 @@
 /**
  * The core syntax objects which define the domain specific language for the upgrade framework.
  * <p>
- * {@link com.vmware.upgrade.dsl.syntax.ScriptSyntax} serves as the primary entry point for
+ * com.vmware.upgrade.dsl.syntax.ScriptSyntax serves as the primary entry point for
  * processing scripts.
  * <p>
  * (Package contains Groovy classes.)

--- a/upgrade-framework-sql-dsl/instructions.bnd
+++ b/upgrade-framework-sql-dsl/instructions.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName: com.vmware.upgrade.sql.dsl
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: *
 Import-Package: com.vmware.upgrade.dsl.syntax,\
   com.vmware.upgrade.sql.task,\

--- a/upgrade-framework-sql-dsl/pom.xml
+++ b/upgrade-framework-sql-dsl/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.vmware.vcloud</groupId>
         <artifactId>upgrade-framework-parent</artifactId>
-        <version>1.0.1</version>
+        <version>2.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -22,6 +22,8 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
+            <version>${groovy.version}</version>
+            <type>pom</type>
         </dependency>
 
         <dependency>

--- a/upgrade-framework-sql-dsl/src/main/java/com/vmware/upgrade/dsl/sql/package-info.java
+++ b/upgrade-framework-sql-dsl/src/main/java/com/vmware/upgrade/dsl/sql/package-info.java
@@ -28,7 +28,7 @@
  * <h3>A simple example</h3>
  * This example demonstrates defining an upgrade which defines a single SQL statement to be
  * executed for all database types.
- * <h4><tt>src/main/resources/upgrade/upgrade.groovy</tt></h4>
+ * <h4><code>src/main/resources/upgrade/upgrade.groovy</code></h4>
  * <pre><code>
  * foo = upgrade {
  *     name "Upgrade to do 'foo'"
@@ -69,7 +69,7 @@
  * The first SQL statement explicitly specifies the SQL to use for each database type while the
  * second demonstrates defining a default value used for all database types for which no SQL is
  * explicitly defined.
- * <h4><tt>src/main/resources/upgrade/upgrade.groovy</tt></h4>
+ * <h4><code>src/main/resources/upgrade/upgrade.groovy</code></h4>
  * <pre><code>
  * foo = upgrade {
  *     name "Upgrade to do 'foo'"
@@ -86,10 +86,10 @@
  *     from "" to "1.0.0" call foo
  * }
  * </code></pre>
- * <h3>Leveraging {@link com.vmware.upgrade.dsl.sql.util.AgnosticSqlProcessor}</h3>
+ * <h3>Leveraging com.vmware.upgrade.dsl.sql.util.AgnosticSqlProcessor</h3>
  * This example demonstrates defining an upgrade which using keywords processed by
- * {@link com.vmware.upgrade.dsl.sql.util.AgnosticSqlProcessor}.
- * <h4><tt>src/main/resources/upgrade/upgrade.groovy</tt></h4>
+ * com.vmware.upgrade.dsl.sql.util.AgnosticSqlProcessor.
+ * <h4><code>src/main/resources/upgrade/upgrade.groovy</code></h4>
  * <pre><code>
  * foo = upgrade {
  *     name "Upgrade to do 'foo'"
@@ -141,4 +141,3 @@
  * @since 1.0
  */
 package com.vmware.upgrade.dsl.sql;
-

--- a/upgrade-framework-sql-dsl/src/main/java/com/vmware/upgrade/dsl/sql/util/NullAware.java
+++ b/upgrade-framework-sql-dsl/src/main/java/com/vmware/upgrade/dsl/sql/util/NullAware.java
@@ -34,6 +34,7 @@ public interface NullAware extends HasClosureMap {
      * Set the allowing of null values.
      *
      * @param arg the {@link Object} used to determine allowing of null values
+     * @return Object
      */
     public Object makeNullable(Object arg);
 

--- a/upgrade-framework-sql/instructions.bnd
+++ b/upgrade-framework-sql/instructions.bnd
@@ -1,4 +1,4 @@
 Bundle-SymbolicName: com.vmware.upgrade.sql
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: *
 Export-Package: *

--- a/upgrade-framework-sql/pom.xml
+++ b/upgrade-framework-sql/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.vmware.vcloud</groupId>
         <artifactId>upgrade-framework-parent</artifactId>
-        <version>1.0.1</version>
+        <version>2.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Update the upgrade-framework to compile using Java 11 and Groovy 3. Had to
switch to using gobuild's MakeHelper instead of MavenHelper because MavenHelper
only looks at versions of maven available in toolchain, which is not being
updated anymore.

Had to make a variety of javadoc changes to appease the newer version
maven-javadoc-plugin which seems to be more strict. I just picked the path of
least resistance in modifying them.

Also updated the project's version to 2.0.0.